### PR TITLE
Serve next build files ++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ client/build
 
 # misc
 client/.DS_Store
+.DS_Store
 
 # debug
 client/npm-debug.log*

--- a/index.js
+++ b/index.js
@@ -1,1 +1,40 @@
-console.log("TODO: Implement express backend server");
+/**
+ * Set up the Next & Express server.
+ * @author Justin Gray (A00426753)
+ */
+const express = require("express");
+const next = require("next");
+
+// @ts-ignore
+const app = next({
+  dir: "./client",
+});
+const handle = app.getRequestHandler();
+const port = 3384;
+
+app
+  .prepare()
+  .then(() => {
+    const server = express();
+
+    // express middleware function(s)
+    server.use(express.json());
+
+    // startup functions
+    require("./startup/routes")(server); // setup '/api' routes
+    require("./startup/database").connect(); // connect to MongoDB
+
+    // render NextJS react content (generated using 'npm run build')
+    server.get("*", (req, res) => {
+      return handle(req, res);
+    });
+
+    // set the server to listen on the given port
+    server.listen(port, (err) => {
+      if (err) throw err;
+      console.log(`Server listening on port ${port}`);
+    });
+  })
+  .catch((err) => {
+    console.error(err);
+  });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A training email system for Autism NS",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "client": "cd client && npm run dev",
+    "dev": "cd client && npm run dev",
+    "build": "cd client && npm run build",
+    "server": "node index.js"
   },
   "repository": {
     "type": "git",
@@ -20,7 +23,9 @@
     "bcrypt": "^5.0.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
-     "mongoose": "^5.10.7",
-    "express": "^4.17.1"
+    "mongoose": "^5.10.8",
+    "next": "9.5.3",
+    "react": "16.13.1",
+    "react-dom": "16.13.1"
   }
 }

--- a/routes/email.js
+++ b/routes/email.js
@@ -1,0 +1,28 @@
+// todo: implement (currently just test data)
+const router = require("express").Router();
+
+const testEmail = {
+  _id: "AIJKSBDakjsdbnJKBKNL",
+  __v: 1,
+  date: Date.now(),
+  subject: "Test Subject",
+  body: "Hello,\nThis is the body of the email.\nThanks",
+  from: {
+    name: "Justin",
+    email: "justin@gray.ca",
+  },
+  to: [
+    {
+      name: "Nicholas",
+      email: "nick@morash.com",
+    },
+  ],
+  cc: [],
+  bcc: [],
+};
+
+router.get("/", (req, res) => {
+  res.send(testEmail);
+});
+
+module.exports = router;

--- a/startup/routes.js
+++ b/startup/routes.js
@@ -1,0 +1,20 @@
+/**
+ * Set up the '/api' route and catch everything that doesn't have a designated router.
+ * @author Justin Gray (A00426753)
+ */
+module.exports = function (app) {
+  // route each endpoint to the proper router file
+  app.use("/api/email", require("../routes/email"));
+
+  // catch-all for /api calls: prevents from serving next content
+  app.use("/api", (req, res) => {
+    res.status(404).send({
+      message:
+        "Endpoint not found. See https://github.com/just1ngray/CSCI3428/wiki/HTTP-Endpoints",
+      url: req.originalUrl,
+      body: req.body,
+      protocol: req.protocol,
+      headers: req.headers,
+    });
+  });
+};


### PR DESCRIPTION
`npm run build` to optimize the files to serve
`npm run server` to run the server on port 3384

`npm run client` or `npm run dev` will continue to be the best method of developing the front-end. Since it doesn't have to be built, and should have auto-refresh capabilities.

This merge request is just a snapshot into how the server will work.

It's only 100ish lines, so it's easier to understand now than at the end of the project. Please comment your questions, comments, and improvements!