### PR TITLE
Fix cors

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start -p 3384"
   },
   "dependencies": {
     "jsonwebtoken": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "A training email system for Autism NS",
   "main": "index.js",
   "scripts": {
-    "client": "cd client && npm run dev",
     "dev": "cd client && npm run dev",
     "build": "cd client && npm run build",
+    "client": "cd client && npm run start",
     "server": "node index.js"
   },
   "repository": {


### PR DESCRIPTION
Next JS seems to heavily push running a server within their framework. However, I (and many other developers) prefer to use a custom server instead. This custom server can be difficult to integrate with Next JS.  

Before:
- Page requests worked on port 3384
- API calls worked on Postman on port 3384
- No API call on a browser was validated past the CORS policy

Now:
- Next JS runs itself (which comes with optimization advantages) on port 3384. In root run `npm run client`
- The Express server manages the database and its operations on port 3385. In root run `npm run server`
- API Calls to the Express server work!
- Non-api requests to the Express server are redirected to port 3384