### PR TITLE
Account model should remember it's child type

### DIFF
--- a/middleware/populateChild.js
+++ b/middleware/populateChild.js
@@ -42,18 +42,20 @@ async function populate(req, res, next) {
       .status(500)
       .send(`That account has an invalid child_id ${child_id}`);
 
-  const student = await Student.findById(child_id);
-  if (student) {
-    req.auth.student = student;
-    next();
-  } else {
+  if (req.auth.account.childType === "specialist") {
     const specialist = await Specialist.findById(child_id);
     if (!specialist)
-      return res
-        .status(500)
-        .send(`No student or specialist with _id ${child_id}`);
+      return res.status(500).send("No specialist found with _id " + child_id);
 
     req.auth.specialist = specialist;
+    next();
+  } else {
+    // must be student
+    const student = await Student.findById(child_id);
+    if (!student)
+      return res.status(500).send("No student found with _id " + child_id);
+
+    req.auth.student = student;
     next();
   }
 }

--- a/models/Account.js
+++ b/models/Account.js
@@ -56,13 +56,18 @@ const accountSchema = new mongoose.Schema({
     type: String,
     maxlength: 128,
   },
+  childType: {
+    type: String,
+    enum: ["specialist", "student"],
+  },
 });
 
 /**
  * Gets the JSONWebToken for the account document
  * Included properties in JWT body:
- *  - _id
- *  - __v
+ *  - _id       - email
+ *  - __v       - child_id
+ *  - name      - childType
  * @author Justin Gray (A00426753)
  */
 accountSchema.methods.getAuthToken = function () {
@@ -73,6 +78,7 @@ accountSchema.methods.getAuthToken = function () {
       name: this.name,
       email: this.email,
       child_id: this.child_id,
+      childType: this.childType,
     },
     String(process.env.G2_JWT)
   );

--- a/routes/account.js
+++ b/routes/account.js
@@ -20,7 +20,10 @@ router.post("/login", async (req, res) => {
 
   const isValidPassword = await account.isValidPassword(password);
   if (isValidPassword) {
-    res.send(account.getAuthToken());
+    res.send({
+      token: account.getAuthToken(),
+      childType: account.childType,
+    });
   } else {
     res.status(403).send("Wrong password.");
   }

--- a/routes/specialist.js
+++ b/routes/specialist.js
@@ -28,6 +28,7 @@ router.post("/sign-up", (req, res) => {
         sent: [],
         contacts: [],
         child_id: String(specialist_id),
+        childType: "specialist",
       });
 
       const specialist = new Specialist({
@@ -75,6 +76,7 @@ router.post("/student", [auth, populateChild], (req, res) => {
     sent: [],
     contacts: [],
     child_id: student_id,
+    childType: "student",
   });
 
   const student = new Student({

--- a/startup/setupAccounts.js
+++ b/startup/setupAccounts.js
@@ -39,6 +39,7 @@ module.exports = async function verifyAccounts() {
       sent: [],
       contacts: [],
       child_id: String(specialistID),
+      childType: "specialist",
     });
     promises.push(specialistAcc.save());
 
@@ -51,6 +52,7 @@ module.exports = async function verifyAccounts() {
       sent: [],
       contacts: [],
       child_id: String(studentID),
+      childType: "student",
     });
     promises.push(studentAcc.save());
 


### PR DESCRIPTION
The account model now has an additional attribute called `childType` to remember if the account is associated with a student or a specialist. This can improve performance in the future, as well as allow for more specific implementations in the front end.

Note that you may have to delete and re-generate the sample accounts so they will have the appropriate `childType` property. Alternatively you can simply add the appropriate property to each account in the collection.

The login endpoint on 200 now returns an object as:
```
{
    token: JSONWebToken (same as before),
    childType: "student" | "specialist"
}
```