### PR TITLE
Allow sending mail to non-account receivers

### DIFF
--- a/models/contactSchema.js
+++ b/models/contactSchema.js
@@ -9,7 +9,7 @@ module.exports = new mongoose.Schema({
     type: String,
     maxlength: 128,
     default: "",
-    required: true,
+    required: false,
   },
   email: {
     type: String,


### PR DESCRIPTION
Previously, POST email would be `400`'d if the `to` field's value was not an email tied to an account.

With this tiny change, emails can now be sent to anyone, even if there is no account to receive the email.