### PR TITLE
401 Redirect

### DIFF
--- a/client/pages/_app.js
+++ b/client/pages/_app.js
@@ -9,6 +9,19 @@ import "../styles/globals.css";
 import "../styles/bulma.css";
 import "tippy.js/dist/tippy.css";
 
+import axios from "axios";
+axios.interceptors.response.use(
+  (res) => {
+    return res;
+  },
+  (err) => {
+    if (err.response.status === 401) {
+      localStorage.removeItem("token");
+      window.location.pathname = "/";
+    } else return Promise.reject(err);
+  }
+);
+
 /**
  * This function applies CSS to website and loads other funtions as needed
  *


### PR DESCRIPTION
Any http request with the error response `401` received through `axios` will now redirect to the login page. See #78 for more details.

Closes #78



We may also be able to have
```
axios.baseUrl = "...";
```
according to the documentation in the _app.js file to implicitly send all HTTP requests to the baseUrl. But this is an issue for another day.