### PR TITLE
Pagination

### DIFF
--- a/client/pages/components/EmailList.js
+++ b/client/pages/components/EmailList.js
@@ -4,6 +4,7 @@
  *
  * @author Nicholas Morash (A00378981)
  * @author Bivash Pandey (A00425523) - search bar and its filter functionality
+ * @author Justin Gray (A00426753) - pagination functionality
  */
 
 import React, { useState, useEffect } from "react";
@@ -11,6 +12,9 @@ import axios from "axios";
 import EmailHeader from "./EmailHeader";
 import defaults from "../../utils/defaults";
 import filterEmails from "../../utils/filterEmails";
+import Pagination from "./Pagination";
+
+const EMAILS_PER_PAGE = 20;
 
 /**
  * This component retrieves and renders a list of emails.
@@ -20,6 +24,7 @@ export default function EmailList({ isSentPage }) {
   const [emails, setEmails] = useState([]);
   const [showEmailIndices, setShowEmailIndices] = useState([]);
   const [searchVal, setSearchVal] = useState("");
+  const [pageNum, setPageNum] = useState(1); // 1 indexed
 
   useEffect(() => {
     setShowEmailIndices(filterEmails(emails, searchVal));
@@ -80,7 +85,11 @@ export default function EmailList({ isSentPage }) {
   else {
     content = [];
     emails
-      .filter((email, index) => showEmailIndices.includes(index))
+      .filter(
+        (email, index) =>
+          showEmailIndices.includes(index) &&
+          Math.floor(index / EMAILS_PER_PAGE) + 1 == pageNum
+      )
       .forEach((email) => {
         content.push(
           <EmailHeader
@@ -108,6 +117,15 @@ export default function EmailList({ isSentPage }) {
         </span>
       </p>
       <br />
+
+      {showEmailIndices.length <= EMAILS_PER_PAGE ? null : (
+        <Pagination
+          itemsPerPage={EMAILS_PER_PAGE}
+          numItems={showEmailIndices.length}
+          setPage={setPageNum}
+          currentPage={pageNum}
+        />
+      )}
 
       <div className="box">
         <p>{content}</p>

--- a/client/pages/components/EmailList.js
+++ b/client/pages/components/EmailList.js
@@ -14,7 +14,7 @@ import defaults from "../../utils/defaults";
 import filterEmails from "../../utils/filterEmails";
 import Pagination from "./Pagination";
 
-const EMAILS_PER_PAGE = 2;
+const EMAILS_PER_PAGE = 20;
 
 /**
  * This component retrieves and renders a list of emails.

--- a/client/pages/components/EmailList.js
+++ b/client/pages/components/EmailList.js
@@ -118,6 +118,10 @@ export default function EmailList({ isSentPage }) {
       </p>
       <br />
 
+      <div className="box" style={{ marginBottom: 1 }}>
+        <p>{content}</p>
+      </div>
+
       {showEmailIndices.length <= EMAILS_PER_PAGE ? null : (
         <Pagination
           itemsPerPage={EMAILS_PER_PAGE}
@@ -126,10 +130,6 @@ export default function EmailList({ isSentPage }) {
           currentPage={pageNum}
         />
       )}
-
-      <div className="box">
-        <p>{content}</p>
-      </div>
     </div>
   );
 }

--- a/client/pages/components/EmailList.js
+++ b/client/pages/components/EmailList.js
@@ -14,7 +14,7 @@ import defaults from "../../utils/defaults";
 import filterEmails from "../../utils/filterEmails";
 import Pagination from "./Pagination";
 
-const EMAILS_PER_PAGE = 20;
+const EMAILS_PER_PAGE = 2;
 
 /**
  * This component retrieves and renders a list of emails.
@@ -28,6 +28,7 @@ export default function EmailList({ isSentPage }) {
 
   useEffect(() => {
     setShowEmailIndices(filterEmails(emails, searchVal));
+    setPageNum(1);
   }, [searchVal]);
 
   // get all the emails
@@ -85,10 +86,9 @@ export default function EmailList({ isSentPage }) {
   else {
     content = [];
     emails
+      .filter((email, index) => showEmailIndices.includes(index))
       .filter(
-        (email, index) =>
-          showEmailIndices.includes(index) &&
-          Math.floor(index / EMAILS_PER_PAGE) + 1 == pageNum
+        (email, index) => Math.floor(index / EMAILS_PER_PAGE) + 1 == pageNum
       )
       .forEach((email) => {
         content.push(

--- a/client/pages/components/Pagination.js
+++ b/client/pages/components/Pagination.js
@@ -1,0 +1,37 @@
+/**
+ * Paginates a dataset to as many pages as needed.
+ * @author Justin Gray (initial creation, but no styling)
+ */
+import React from "react";
+
+/**
+ * Paginates a dataset to as many pages as needed.
+ * @props numItems      the number of items in the dataset
+ * @props itemsPerPage  the number of items that can be on a single page
+ * @props currentPage   the current page (1 indexed)
+ * @props setPage       set the new page to view
+ */
+export default function Pagination({
+  numItems,
+  itemsPerPage,
+  currentPage,
+  setPage,
+}) {
+  const pages = [];
+  [...new Array(Math.ceil(numItems / itemsPerPage)).keys()].forEach(
+    (pageNum) => {
+      pages.push(
+        <button
+          key={pageNum + 1}
+          type="button"
+          onClick={() => setPage(pageNum + 1)}
+          className={`button ${currentPage === pageNum + 1 ? "is-info" : ""}`}
+        >
+          {pageNum + 1}
+        </button>
+      );
+    }
+  );
+
+  return <div>{pages}</div>;
+}

--- a/client/pages/components/Pagination.js
+++ b/client/pages/components/Pagination.js
@@ -1,6 +1,6 @@
 /**
  * Paginates a dataset to as many pages as needed.
- * @author Justin Gray (initial creation, but no styling)
+ * @author Justin Gray - all of it
  */
 import React from "react";
 
@@ -33,5 +33,5 @@ export default function Pagination({
     }
   );
 
-  return <div>{pages}</div>;
+  return <div className="buttons has-addons">{pages}</div>;
 }


### PR DESCRIPTION
Paginate the EmailList into pages of 20 emails.
<img width="1333" alt="Screen Shot 2020-12-09 at 9 45 59 PM" src="https://user-images.githubusercontent.com/57203324/101711052-2748ed80-3a69-11eb-87e0-7744dc43c8d5.png">

This is search-compatible. 
<img width="1333" alt="Screen Shot 2020-12-09 at 9 52 01 PM" src="https://user-images.githubusercontent.com/57203324/101711063-2c0da180-3a69-11eb-82c2-a7375ab80c42.png">

Note that this was tested with page size of 2 but the real version has 20 emails.
Also note that the pagination buttons only appear when there are more than 20 emails